### PR TITLE
updated sign_up form to include phone number in response

### DIFF
--- a/gscript/sign_up.gs
+++ b/gscript/sign_up.gs
@@ -48,6 +48,7 @@ class Member {
     this.email = "";
     this.school = "";
     this.department = "";
+    this.phone_number = "";
   }
 }
 
@@ -74,6 +75,9 @@ function createMember(itemResponses) {
         break;
       case "What is your BU email address?":
         member.email = response;
+        break;
+      case "What is your phone number?":
+        member.phone_number = response;
         break;
       case "Are you in a Doctoral program (PhD, J.D. etc)":
         if (response == "No") {


### PR DESCRIPTION
We need phone number for twilio `to` field, so added question to google form and extract the value from response.
Added a question for phone number in the google form and a regex expression to only accept 10 digit numbers.